### PR TITLE
Enable streaming TTS playback

### DIFF
--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -674,13 +674,13 @@ export const useSpeechToTextMutation = (
 export const useTextToSpeechMutation = (
   options?: t.TextToSpeechOptions,
 ): UseMutationResult<
-  ArrayBuffer, // response data
+  ArrayBuffer | Response, // response data
   unknown, // error
   FormData, // request
   unknown // context
 > => {
   return useMutation([MutationKeys.textToSpeech], {
-    mutationFn: (variables: FormData) => dataService.textToSpeech(variables),
+    mutationFn: (variables: FormData) => dataService.textToSpeechStream(variables),
     ...(options || {}),
   });
 };

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -1,4 +1,5 @@
 import type { AxiosResponse } from 'axios';
+import axios from 'axios';
 import type * as t from './types';
 import * as endpoints from './api-endpoints';
 import * as a from './types/assistants';
@@ -536,8 +537,17 @@ export const textToSpeech = (data: FormData): Promise<ArrayBuffer> => {
   return request.postTTS(endpoints.textToSpeechManual(), data);
 };
 
-export const textToSpeechStream = (data: FormData): Promise<ArrayBuffer> => {
-  return request.postTTS(endpoints.textToSpeechStream(), data);
+export const textToSpeechStream = async (data: FormData): Promise<Response> => {
+  const headers: Record<string, string> = {};
+  const auth = axios.defaults.headers.common['Authorization'];
+  if (auth) {
+    headers['Authorization'] = auth as string;
+  }
+  return fetch(endpoints.textToSpeechStream(), {
+    method: 'POST',
+    headers,
+    body: data,
+  });
 };
 
 export const getVoices = (): Promise<f.VoiceResponse> => {

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -110,7 +110,7 @@ export type SpeechToTextOptions = {
 };
 
 export type TextToSpeechOptions = {
-  onSuccess?: (data: ArrayBuffer, variables: FormData, context?: unknown) => void;
+  onSuccess?: (data: ArrayBuffer | Response, variables: FormData, context?: unknown) => void;
   onMutate?: (variables: FormData) => void | Promise<unknown>;
   onError?: (error: unknown, variables: FormData, context?: unknown) => void;
 };


### PR DESCRIPTION
## Summary
- adjust `TextToSpeechOptions` type to allow streaming `Response`
- change TTS streaming call to `fetch` with auth header
- update mutation to use streaming endpoint

## Testing
- `npm run lint` *(fails: 765 problems)*
- `npm run test:client` *(fails: module resolution errors)*