### PR TITLE
Add manual TTS streaming option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ Click on the thumbnail to open the video☝️
 
 ---
 
+## Developer Notes
+
+- A hidden option `streamManualTTS` enables streaming audio for manual text-to-speech. Toggle it via the `StreamManualTTS` switch when the `SHOW_STREAM_MANUAL_TTS_TOGGLE` constant is set to `true`.
+
+---
+
 ## 📝 Changelog
 
 Keep up with the latest updates by visiting the releases page and notes:

--- a/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
+++ b/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
@@ -11,6 +11,7 @@ import {
   CacheTTSSwitch,
   VoiceDropdown,
   PlaybackRate,
+  StreamManualTTSSwitch,
 } from './TTS';
 import {
   AutoTranscribeAudioSwitch,
@@ -234,6 +235,7 @@ function Speech() {
             <PlaybackRate />
           </div>
           <CacheTTSSwitch />
+          <StreamManualTTSSwitch />
         </div>
       </Tabs.Content>
     </Tabs.Root>

--- a/client/src/components/Nav/SettingsTabs/Speech/TTS/StreamManualTTSSwitch.tsx
+++ b/client/src/components/Nav/SettingsTabs/Speech/TTS/StreamManualTTSSwitch.tsx
@@ -1,0 +1,39 @@
+import { useRecoilState } from 'recoil';
+import { Switch } from '~/components/ui';
+import { useLocalize } from '~/hooks';
+import store from '~/store';
+
+export const SHOW_STREAM_MANUAL_TTS_TOGGLE = true;
+
+export default function StreamManualTTSSwitch({
+  onCheckedChange,
+}: {
+  onCheckedChange?: (value: boolean) => void;
+}) {
+  const localize = useLocalize();
+  const [streamManualTTS, setStreamManualTTS] = useRecoilState<boolean>(store.streamManualTTS);
+  const [textToSpeech] = useRecoilState<boolean>(store.textToSpeech);
+
+  if (!SHOW_STREAM_MANUAL_TTS_TOGGLE) {
+    return null;
+  }
+
+  const handleCheckedChange = (value: boolean) => {
+    setStreamManualTTS(value);
+    onCheckedChange?.(value);
+  };
+
+  return (
+    <div className="flex items-center justify-between">
+      <div>{localize('com_nav_stream_manual_tts')}</div>
+      <Switch
+        id="StreamManualTTS"
+        checked={streamManualTTS}
+        onCheckedChange={handleCheckedChange}
+        className="ml-4"
+        data-testid="StreamManualTTS"
+        disabled={!textToSpeech}
+      />
+    </div>
+  );
+}

--- a/client/src/components/Nav/SettingsTabs/Speech/TTS/index.ts
+++ b/client/src/components/Nav/SettingsTabs/Speech/TTS/index.ts
@@ -5,3 +5,4 @@ export { default as EngineTTSDropdown } from './EngineTTSDropdown';
 export { default as CacheTTSSwitch } from './CacheTTSSwitch';
 export { default as VoiceDropdown } from './VoiceDropdown';
 export { default as PlaybackRate } from './PlaybackRate';
+export { default as StreamManualTTSSwitch } from './StreamManualTTSSwitch';

--- a/client/src/hooks/Input/useTextToSpeechExternal.ts
+++ b/client/src/hooks/Input/useTextToSpeechExternal.ts
@@ -1,7 +1,9 @@
 import { useRecoilValue } from 'recoil';
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
+import { MediaSourceAppender } from '~/hooks/Audio';
 import { useTextToSpeechMutation, useVoicesQuery } from '~/data-provider';
 import { useToastContext } from '~/Providers/ToastContext';
+import { useAuthContext } from '~/hooks/AuthContext';
 import useLocalize from '~/hooks/useLocalize';
 import store from '~/store';
 
@@ -31,11 +33,15 @@ function useTextToSpeechExternal({
   const { showToast } = useToastContext();
   const voice = useRecoilValue(store.voice);
   const cacheTTS = useRecoilValue(store.cacheTTS);
+  const streamManualTTS = useRecoilValue(store.streamManualTTS);
   const playbackRate = useRecoilValue(store.playbackRate);
 
   const [downloadFile, setDownloadFile] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
 
   const promiseAudioRef = useRef<HTMLAudioElement | null>(null);
+  const mediaSourceRef = useRef<MediaSourceAppender | null>(null);
+  const streamUrlRef = useRef<string | null>(null);
 
   /* Global Audio Variables */
   const globalIsFetching = useRecoilValue(store.globalAudioFetchingFamily(index));
@@ -132,13 +138,99 @@ function useTextToSpeechExternal({
     },
   });
 
+  const { token } = useAuthContext();
+
   const startMutation = (text: string, download: boolean) => {
     const formData = createFormData(text, voice ?? '');
     setDownloadFile(download);
     processAudio(formData);
   };
 
+  const startStreaming = async (text: string, download: boolean) => {
+    const formData = createFormData(text, voice ?? '');
+    setDownloadFile(download);
+    setIsStreaming(true);
+    try {
+      const response = await fetch('/api/files/speech/tts/manual', {
+        method: 'POST',
+        body: formData,
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error('Failed to fetch audio');
+      }
+
+      const reader = response.body.getReader();
+      const type = 'audio/mpeg';
+      const browserSupportsType =
+        typeof MediaSource !== 'undefined' && MediaSource.isTypeSupported(type);
+      const chunks: ArrayBuffer[] = [];
+      let mediaSource: MediaSourceAppender | null = null;
+
+      if (browserSupportsType) {
+        mediaSource = new MediaSourceAppender(type);
+        mediaSourceRef.current = mediaSource;
+        streamUrlRef.current = mediaSource.mediaSourceUrl;
+        autoPlayAudio(streamUrlRef.current);
+      }
+
+      let done = false;
+      while (!done) {
+        const { value, done: readerDone } = await reader.read();
+        if (value) {
+          // Create a new ArrayBuffer from the Uint8Array
+          const buffer = value.buffer.slice(
+            value.byteOffset,
+            value.byteOffset + value.byteLength
+          ) as ArrayBuffer;
+      
+          if (cacheTTS) {
+            chunks.push(buffer);
+          }
+          if (browserSupportsType && mediaSource) {
+            mediaSource.addData(buffer);
+          }
+        }
+        done = readerDone;
+      }
+
+      mediaSource?.close();
+
+      if (chunks.length) {
+        const audioBlob = new Blob(chunks, { type });
+        if (cacheTTS && text) {
+          const cache = await caches.open('tts-responses');
+          await cache.put(new Request(text), new Response(audioBlob));
+        }
+        if (!browserSupportsType) {
+          const blobUrl = URL.createObjectURL(audioBlob);
+          streamUrlRef.current = blobUrl;
+          autoPlayAudio(blobUrl);
+          if (download) {
+            downloadAudio(blobUrl);
+          }
+        } else if (download) {
+          const blobUrl = URL.createObjectURL(audioBlob);
+          downloadAudio(blobUrl);
+        }
+      }
+    } catch (error) {
+      showToast({
+        message: localize('com_nav_audio_process_error', { 0: (error as Error).message }),
+        status: 'error',
+      });
+    } finally {
+      setIsStreaming(false);
+    }
+  };
+
   const generateSpeechExternal = (text: string, download: boolean) => {
+    if (streamManualTTS) {
+      startStreaming(text, download);
+      return;
+    }
+
     if (cacheTTS) {
       handleCachedResponse(text, download);
     } else {
@@ -171,6 +263,15 @@ function useTextToSpeechExternal({
     };
     pauseAudio(messageAudio);
     pauseAudio(promiseAudioRef.current);
+    pauseAudio(audioRef.current);
+    if (streamUrlRef.current) {
+      URL.revokeObjectURL(streamUrlRef.current);
+      streamUrlRef.current = null;
+    }
+    if (mediaSourceRef.current) {
+      mediaSourceRef.current.close();
+      mediaSourceRef.current = null;
+    }
     setIsSpeaking(false);
   };
 
@@ -195,7 +296,7 @@ function useTextToSpeechExternal({
   return {
     generateSpeechExternal,
     cancelSpeech,
-    isLoading: isFetching || isLoading,
+    isLoading: isFetching || isLoading || isStreaming,
     audioRef,
     voices: voicesData,
   };

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -324,6 +324,7 @@
   "com_nav_delete_warning": "WARNING: This will permanently delete your account.",
   "com_nav_edit_chat_badges": "Edit Chat Badges",
   "com_nav_enable_cache_tts": "Enable cache TTS",
+  "com_nav_stream_manual_tts": "Stream manual TTS",
   "com_nav_enable_cloud_browser_voice": "Use cloud-based voices",
   "com_nav_enabled": "Enabled",
   "com_nav_engine": "Engine",

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -73,6 +73,7 @@ const localStorageAtoms = {
   automaticPlayback: atomWithLocalStorage('automaticPlayback', false),
   playbackRate: atomWithLocalStorage<number | null>('playbackRate', null),
   cacheTTS: atomWithLocalStorage('cacheTTS', true),
+  streamManualTTS: atomWithLocalStorage('streamManualTTS', false),
 
   // Account settings
   UsernameDisplay: atomWithLocalStorage('UsernameDisplay', true),


### PR DESCRIPTION
## Summary
- add `streamManualTTS` recoil setting
- implement streaming support in `useTextToSpeechExternal`
- expose hidden `StreamManualTTSSwitch`
- document developer setting in README

## Testing
- `npx lint-staged --config ./.husky/lint-staged.config.js`
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*