### PR TITLE
Implement audio state manager

### DIFF
--- a/client/src/hooks/Audio/useCustomAudioRef.ts
+++ b/client/src/hooks/Audio/useCustomAudioRef.ts
@@ -14,13 +14,13 @@ interface CustomAudioElement extends HTMLAudioElement {
 type TCustomAudioResult = { audioRef: React.MutableRefObject<CustomAudioElement | null> };
 
 export default function useCustomAudioRef({
-  setIsPlaying,
-  setIsFetching,
-  clearRequest,
+  onPlay,
+  onPause,
+  onEnded,
 }: {
-  setIsPlaying: (isPlaying: boolean) => void;
-  setIsFetching?: (isFetching: boolean) => void;
-  clearRequest?: () => void;
+  onPlay?: () => void;
+  onPause?: () => void;
+  onEnded?: () => void;
 }): TCustomAudioResult {
   const audioRef = useRef<CustomAudioElement | null>(null);
   useEffect(() => {
@@ -35,10 +35,8 @@ export default function useCustomAudioRef({
     let sameTimeUpdateCount = 0;
 
     const handleEnded = () => {
-      setIsPlaying(false);
-      // Clear request when playback ends to reset button state
-      if (clearRequest) {
-        clearRequest();
+      if (onEnded) {
+        onEnded();
       }
       console.log('global audio ended');
       if (audioRef.current) {
@@ -49,10 +47,8 @@ export default function useCustomAudioRef({
     };
 
     const handleStart = () => {
-      // Clear fetching spinner and show stop button when audio actually starts playing
-      setIsPlaying(true);
-      if (setIsFetching) {
-        setIsFetching(false);
+      if (onPlay) {
+        onPlay();
       }
       console.log('global audio started');
       if (audioRef.current) {
@@ -62,6 +58,9 @@ export default function useCustomAudioRef({
 
     const handlePause = () => {
       console.log('global audio paused');
+      if (onPause) {
+        onPause();
+      }
       if (audioRef.current) {
         audioRef.current.customPaused = true;
       }

--- a/client/src/store/audioManager.ts
+++ b/client/src/store/audioManager.ts
@@ -1,0 +1,55 @@
+import { useRecoilCallback } from 'recoil';
+import store from '~/store';
+
+export default function useAudioStateManager(messageId: string | null) {
+  const setPlaying = useRecoilCallback(({ set }) => (value: boolean) => {
+    set(store.globalAudioPlayingFamily(messageId), value);
+  }, [messageId]);
+
+  const setFetching = useRecoilCallback(({ set }) => (value: boolean) => {
+    set(store.globalAudioFetchingFamily(messageId), value);
+  }, [messageId]);
+
+  const setURL = useRecoilCallback(({ set }) => (url: string | null) => {
+    set(store.globalAudioURLFamily(messageId), url);
+  }, [messageId]);
+
+  const setRunId = useRecoilCallback(({ set }) => (runId: string | null) => {
+    set(store.audioRunFamily(messageId), runId);
+  }, [messageId]);
+
+  const startRequest = (runId: string | null) => {
+    setRunId(runId);
+    setFetching(true);
+    setPlaying(false);
+  };
+
+  const startPlaying = () => {
+    setFetching(false);
+    setPlaying(true);
+  };
+
+  const pausePlayback = () => {
+    setPlaying(false);
+  };
+
+  const clearFetching = () => {
+    setFetching(false);
+  };
+
+  const endPlayback = () => {
+    setPlaying(false);
+    setFetching(false);
+    setURL(null);
+    setRunId(null);
+  };
+
+  return {
+    setURL,
+    startRequest,
+    startPlaying,
+    clearFetching,
+    pausePlayback,
+    endPlayback,
+  };
+}


### PR DESCRIPTION
## Summary
- centralize TTS playback state logic
- handle audio events via callbacks in `useCustomAudioRef`
- manage all playback state transitions from `AudioPlayer` through a new `useAudioStateManager` hook

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*
- `npm run lint` *(fails: 737 errors, 57 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68526b8864fc832fac314de35de01a76