### PR TITLE
Improve TTS state management

### DIFF
--- a/client/src/components/Audio/AudioPlayer.tsx
+++ b/client/src/components/Audio/AudioPlayer.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { useAuthContext } from '~/hooks';
-import { MediaSourceAppender, useCustomAudioRef, usePauseGlobalAudio } from '~/hooks/Audio';
+import { MediaSourceAppender, useCustomAudioRef, usePauseGlobalAudio, useAudioStateManager } from '~/hooks/Audio';
 import store from '~/store';
 import audioStore, { TTSAudioRequest } from '~/store/audio';
 import { globalAudioId } from '~/common';
@@ -23,14 +23,15 @@ export default function AudioPlayer() {
   const playbackRate = useRecoilValue(store.playbackRate);
   const voice = useRecoilValue(store.voice);
 
-  const index = request?.index ?? 0;
   const messageId = request?.messageId ?? null;
-  const setIsPlaying = useSetRecoilState(store.globalAudioPlayingFamily(messageId));
-  const [globalAudioURL, setGlobalAudioURL] = useRecoilState(store.globalAudioURLFamily(messageId));
-  const [isFetching, setIsFetching] = useRecoilState(store.globalAudioFetchingFamily(messageId));
-  const { audioRef } = useCustomAudioRef({ setIsPlaying });
+  const audioManager = useAudioStateManager(messageId);
+  const [globalAudioURL] = useRecoilState(store.globalAudioURLFamily(messageId));
+  const { audioRef } = useCustomAudioRef({
+    onPlay: audioManager.startPlayback,
+    onPause: audioManager.stopPlayback,
+    onEnded: audioManager.stopPlayback,
+  });
   const { pauseGlobalAudio } = usePauseGlobalAudio(messageId);
-  const setAudioRunId = useSetRecoilState(store.audioRunFamily(messageId));
 
   useEffect(() => {
     if (!request) {
@@ -38,13 +39,11 @@ export default function AudioPlayer() {
     }
 
     async function fetchAudio(req: TTSAudioRequest) {
-      setIsFetching(true);
-      setAudioRunId(req.runId ?? null);
+      audioManager.startRequest(req.runId ?? null);
       try {
         if (audioRef.current) {
           audioRef.current.pause();
-          URL.revokeObjectURL(audioRef.current.src);
-          setGlobalAudioURL(null);
+          audioManager.setURL(null);
         }
 
         let cacheKey = req.messageId;
@@ -55,8 +54,8 @@ export default function AudioPlayer() {
           logger.log('Audio found in cache');
           const audioBlob = await cachedResponse.blob();
           const blobUrl = URL.createObjectURL(audioBlob);
-          setGlobalAudioURL(blobUrl);
-          setIsFetching(false);
+          audioManager.setURL(blobUrl);
+          audioManager.finishRequest();
           setRequest(null);
           return;
         }
@@ -78,7 +77,7 @@ export default function AudioPlayer() {
         let mediaSource: MediaSourceAppender | undefined;
         if (browserSupportsType) {
           mediaSource = new MediaSourceAppender(type);
-          setGlobalAudioURL(mediaSource.mediaSourceUrl);
+          audioManager.setURL(mediaSource.mediaSourceUrl);
         }
 
         let done = false;
@@ -105,7 +104,7 @@ export default function AudioPlayer() {
           await cache.put(cacheKey, cachedResponse);
           if (!browserSupportsType) {
             const blobUrl = URL.createObjectURL(audioBlob);
-            setGlobalAudioURL(blobUrl);
+            audioManager.setURL(blobUrl);
           }
         }
 
@@ -116,9 +115,9 @@ export default function AudioPlayer() {
           return;
         }
         logger.error('Error fetching audio:', error);
-        setGlobalAudioURL(null);
+        audioManager.setURL(null);
       } finally {
-        setIsFetching(false);
+        audioManager.finishRequest();
         setRequest(null);
       }
     }

--- a/client/src/hooks/Audio/index.ts
+++ b/client/src/hooks/Audio/index.ts
@@ -2,3 +2,4 @@ export * from './MediaSourceAppender';
 export { default as useCustomAudioRef } from './useCustomAudioRef';
 export { default as usePauseGlobalAudio } from './usePauseGlobalAudio';
 export { default as useTTSBrowser } from './useTTSBrowser';
+export { default as useAudioStateManager } from './useAudioStateManager';

--- a/client/src/hooks/Audio/useAudioStateManager.ts
+++ b/client/src/hooks/Audio/useAudioStateManager.ts
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import { useSetRecoilState, useRecoilState } from 'recoil';
+import store from '~/store';
+
+export default function useAudioStateManager(messageId: string | null = null) {
+  const [audioURL, setAudioURL] = useRecoilState(store.globalAudioURLFamily(messageId));
+  const setIsFetching = useSetRecoilState(store.globalAudioFetchingFamily(messageId));
+  const setIsPlaying = useSetRecoilState(store.globalAudioPlayingFamily(messageId));
+  const setActiveRunId = useSetRecoilState(store.activeRunFamily(messageId));
+  const setAudioRunId = useSetRecoilState(store.audioRunFamily(messageId));
+
+  const startRequest = useCallback(
+    (runId?: string | null) => {
+      setIsFetching(true);
+      if (runId !== undefined) {
+        setAudioRunId(runId);
+        setActiveRunId(runId);
+      }
+    },
+    [setIsFetching, setAudioRunId, setActiveRunId],
+  );
+
+  const finishRequest = useCallback(() => {
+    setIsFetching(false);
+  }, [setIsFetching]);
+
+  const setURL = useCallback(
+    (url: string | null) => {
+      if (audioURL) {
+        URL.revokeObjectURL(audioURL);
+      }
+      setAudioURL(url);
+    },
+    [audioURL, setAudioURL],
+  );
+
+  const startPlayback = useCallback(() => {
+    setIsPlaying(true);
+  }, [setIsPlaying]);
+
+  const stopPlayback = useCallback(() => {
+    setIsPlaying(false);
+  }, [setIsPlaying]);
+
+  const clear = useCallback(() => {
+    if (audioURL) {
+      URL.revokeObjectURL(audioURL);
+    }
+    setAudioURL(null);
+    setIsPlaying(false);
+    setIsFetching(false);
+    setActiveRunId(null);
+    setAudioRunId(null);
+  }, [audioURL, setAudioURL, setIsPlaying, setIsFetching, setActiveRunId, setAudioRunId]);
+
+  return {
+    startRequest,
+    finishRequest,
+    startPlayback,
+    stopPlayback,
+    setURL,
+    clear,
+  };
+}

--- a/client/src/hooks/Audio/useCustomAudioRef.ts
+++ b/client/src/hooks/Audio/useCustomAudioRef.ts
@@ -14,9 +14,13 @@ interface CustomAudioElement extends HTMLAudioElement {
 type TCustomAudioResult = { audioRef: React.MutableRefObject<CustomAudioElement | null> };
 
 export default function useCustomAudioRef({
-  setIsPlaying,
+  onPlay,
+  onPause,
+  onEnded,
 }: {
-  setIsPlaying: (isPlaying: boolean) => void;
+  onPlay: () => void;
+  onPause: () => void;
+  onEnded: () => void;
 }): TCustomAudioResult {
   const audioRef = useRef<CustomAudioElement | null>(null);
   useEffect(() => {
@@ -24,7 +28,7 @@ export default function useCustomAudioRef({
     let sameTimeUpdateCount = 0;
 
     const handleEnded = () => {
-      setIsPlaying(false);
+      onEnded();
       console.log('global audio ended');
       if (audioRef.current) {
         audioRef.current.customEnded = true;
@@ -33,7 +37,7 @@ export default function useCustomAudioRef({
     };
 
     const handleStart = () => {
-      setIsPlaying(true);
+      onPlay();
       console.log('global audio started');
       if (audioRef.current) {
         audioRef.current.customStarted = true;
@@ -42,6 +46,7 @@ export default function useCustomAudioRef({
 
     const handlePause = () => {
       console.log('global audio paused');
+      onPause();
       if (audioRef.current) {
         audioRef.current.customPaused = true;
       }
@@ -92,7 +97,7 @@ export default function useCustomAudioRef({
         URL.revokeObjectURL(audioElement.src);
       }
     };
-  }, [setIsPlaying]);
+  }, [onPlay, onPause, onEnded]);
 
   return { audioRef };
 }

--- a/client/src/hooks/Audio/usePauseGlobalAudio.ts
+++ b/client/src/hooks/Audio/usePauseGlobalAudio.ts
@@ -1,15 +1,12 @@
 import { useCallback } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { globalAudioId } from '~/common';
 import store from '~/store';
+import useAudioStateManager from './useAudioStateManager';
 
 function usePauseGlobalAudio(messageId: string | null = null) {
-  /* Global Audio Variables */
-  const setAudioRunId = useSetRecoilState(store.audioRunFamily(messageId));
-  const setActiveRunId = useSetRecoilState(store.activeRunFamily(messageId));
-  const setGlobalIsPlaying = useSetRecoilState(store.globalAudioPlayingFamily(messageId));
-  const setIsGlobalAudioFetching = useSetRecoilState(store.globalAudioFetchingFamily(messageId));
-  const [globalAudioURL, setGlobalAudioURL] = useRecoilState(store.globalAudioURLFamily(messageId));
+  const { clear, stopPlayback } = useAudioStateManager(messageId);
+  const globalAudioURL = useRecoilValue(store.globalAudioURLFamily(messageId));
 
   const pauseGlobalAudio = useCallback(() => {
     if (globalAudioURL != null && globalAudioURL !== '') {
@@ -17,22 +14,11 @@ function usePauseGlobalAudio(messageId: string | null = null) {
       if (globalAudio) {
         console.log('Pausing global audio', globalAudioURL);
         (globalAudio as HTMLAudioElement).pause();
-        setGlobalIsPlaying(false);
+        stopPlayback();
       }
-      URL.revokeObjectURL(globalAudioURL);
-      setIsGlobalAudioFetching(false);
-      setGlobalAudioURL(null);
-      setActiveRunId(null);
-      setAudioRunId(null);
+      clear();
     }
-  }, [
-    setAudioRunId,
-    setActiveRunId,
-    globalAudioURL,
-    setGlobalAudioURL,
-    setGlobalIsPlaying,
-    setIsGlobalAudioFetching,
-  ]);
+  }, [clear, globalAudioURL, stopPlayback]);
 
   return { pauseGlobalAudio };
 }


### PR DESCRIPTION
## Summary
- centralize audio state transitions via `useAudioStateManager`
- update `AudioPlayer` to use the new manager
- refactor `usePauseGlobalAudio` and `useCustomAudioRef` to rely on manager
- export manager from hooks index

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*
- `npm run test:api` *(fails: Cannot find module 'librechat-data-provider')*

------
https://chatgpt.com/codex/tasks/task_e_68532300aae8832f973f435037f79e6d